### PR TITLE
downgrade jenalibs

### DIFF
--- a/jenabean/pom.xml
+++ b/jenabean/pom.xml
@@ -46,12 +46,12 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>4.3.2</version>
+            <version>3.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>4.3.2</version>
+            <version>3.17.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
In order to keep SDB compatibility the jenalibs have been downgraded to version v3.17.0